### PR TITLE
Develop

### DIFF
--- a/QuickTalk/chats/serializers.py
+++ b/QuickTalk/chats/serializers.py
@@ -235,6 +235,27 @@ class ChatDeleteSerializer(serializers.ModelSerializer):
 
 
 class JoinToGroupChatSerializer(serializers.Serializer):
+    """
+    Serializer to validate and process user join requests for a group chat.
+
+    Fields:
+        - user_id_to_join (IntegerField): ID of the user who is requesting to join the chat. Required.
+        - chat_id_to_join (IntegerField): ID of the chat to be joined. Required.
+
+    Validation:
+        - Checks if both the user and chat with the provided IDs exist.
+        - If either the user or chat does not exist, raises a ValidationError with the message "Object does not exist."
+        - Verifies if the user is already a member of the chat.
+            - If the user is already in the chat, raises an `AlreadyJoinedChatException`.
+            - Otherwise, adds the user to the chat.
+
+    Returns:
+        - The validated data if the user is successfully added to the chat.
+
+    Raises:
+        - ValidationError: If the specified user or chat does not exist.
+        - AlreadyJoinedChatException: If the user is already a member of the specified chat.
+    """
     user_id_to_join = serializers.IntegerField(required=True)
     chat_id_to_join = serializers.IntegerField(required=True)
 
@@ -247,11 +268,8 @@ class JoinToGroupChatSerializer(serializers.Serializer):
             raise serializers.ValidationError(_("Object does not exist."))
 
         already_joined = chat.users.filter(id=user.id).exists()
-        print(already_joined)
 
         if already_joined:
-            print('вызов')
             raise AlreadyJoinedChatException()
         chat.users.add(user)
-        print('Не будет выполняться, если пользователь уже есть')
         return data

--- a/QuickTalk/chats/views.py
+++ b/QuickTalk/chats/views.py
@@ -208,16 +208,29 @@ class ChatDeleteAPIView(APIView):
 
 
 class JoinToGroupChatAPIView(APIView):
+    """
+    API view to handle requests for adding a user to a group chat.
+
+    This endpoint accepts a POST request with necessary data to add a user to a specified group chat.
+    The request data is validated by the `JoinToGroupChatSerializer`, ensuring that the provided information
+    meets the required criteria. If validation passes, the user is added to the group chat.
+
+    Permission:
+        - Only authenticated users are allowed to access this endpoint.
+
+    Raises:
+        - ValidationError: If the data fails to validate, an exception is raised, and a 400 response is returned.
+
+    Returns:
+        - 201 Created: When the user is successfully added to the chat, a success message is returned.
+    """
+    
     permission_classes = [IsAuthenticated]
 
     def post(self, request, *args, **kwargs):
         srlz = JoinToGroupChatSerializer(data=request.data)
         srlz.is_valid(raise_exception=True)
 
-        print('будет выполнено, если пользователь не добавлен')
         return Response({
             'detail': _('The user was successfully added to the chat.'),
         }, status=status.HTTP_201_CREATED)
-        
-
-    

--- a/QuickTalk/static/js/chats/grp-cht-dtl-from-search.js
+++ b/QuickTalk/static/js/chats/grp-cht-dtl-from-search.js
@@ -51,7 +51,6 @@ document.addEventListener('DOMContentLoaded', function () {
             })
             .then(response => response.json())
             .then(data => {
-                console.log(data)
                 if (data.detail === "The user has already joined this group chat.") {
                     alert("You are already joined to this chat. Redirecting...");
                     window.location.href = window.LIST_API_CHATS;


### PR DESCRIPTION
### Work has been done on cleaning the code:
#### the blocks for checking the code have been removed

### DOC-strings have been added for missing elements:
- serializers.py:
```
class JoinToGroupChatSerializer(serializers.Serializer):
    """
    Serializer to validate and process user join requests for a group chat.

    Fields:
        - user_id_to_join (IntegerField): ID of the user who is requesting to join the chat. Required.
        - chat_id_to_join (IntegerField): ID of the chat to be joined. Required.

    Validation:
        - Checks if both the user and chat with the provided IDs exist.
        - If either the user or chat does not exist, raises a ValidationError with the message "Object does not exist."
        - Verifies if the user is already a member of the chat.
            - If the user is already in the chat, raises an `AlreadyJoinedChatException`.
            - Otherwise, adds the user to the chat.

    Returns:
        - The validated data if the user is successfully added to the chat.

    Raises:
        - ValidationError: If the specified user or chat does not exist.
        - AlreadyJoinedChatException: If the user is already a member of the specified chat.
    """
    user_id_to_join = serializers.IntegerField(required=True)
    chat_id_to_join = serializers.IntegerField(required=True)

    def validate(self, data):
        try:
            user = CustomUser.objects.get(id=data['user_id_to_join'])
            chat = Chat.objects.get(id=data['chat_id_to_join'])

        except (Chat.DoesNotExist, CustomUser.DoesNotExist):
            raise serializers.ValidationError(_("Object does not exist."))

        already_joined = chat.users.filter(id=user.id).exists()

        if already_joined:
            raise AlreadyJoinedChatException()
        chat.users.add(user)
        return data
```
- views.py:
```
class JoinToGroupChatAPIView(APIView):
    """
    API view to handle requests for adding a user to a group chat.

    This endpoint accepts a POST request with necessary data to add a user to a specified group chat.
    The request data is validated by the `JoinToGroupChatSerializer`, ensuring that the provided information
    meets the required criteria. If validation passes, the user is added to the group chat.

    Permission:
        - Only authenticated users are allowed to access this endpoint.

    Raises:
        - ValidationError: If the data fails to validate, an exception is raised, and a 400 response is returned.

    Returns:
        - 201 Created: When the user is successfully added to the chat, a success message is returned.
    """
    
    permission_classes = [IsAuthenticated]

    def post(self, request, *args, **kwargs):
        srlz = JoinToGroupChatSerializer(data=request.data)
        srlz.is_valid(raise_exception=True)

        return Response({
            'detail': _('The user was successfully added to the chat.'),
        }, status=status.HTTP_201_CREATED)
 
```